### PR TITLE
Correct copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
     <div class="content has-text-centered">
-        <p>Project Waterfall, © 2019 Michael Pyne.</p>
+        <p>Project Waterfall, © 2020 Michael Pyne.</p>
         <p>Uses <a href="https://bulma.io/">Bulma</a> and <a
             href="https://fontawesome.com/">Font Awesome</a>.</p>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
     <div class="content has-text-centered">
-        <p>Project Waterfall, © 2020 Michael Pyne.</p>
+        <p>Project Waterfall, © 2021 Michael Pyne.</p>
         <p>Uses <a href="https://bulma.io/">Bulma</a> and <a
             href="https://fontawesome.com/">Font Awesome</a>.</p>
     </div>


### PR DESCRIPTION
The site has been updated a few times since 2019 but the footer still says 2019. Update it to match the current year.