### PR TITLE
Correct hyperlinks to point to the updated MyNavy HR website.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,12 +94,12 @@
               <div class="tile is-parent">
                 <div class="box tile is-child">
                     <p class="heading">NAVADMIN 216/19</p>
-                    <a href="https://www.public.navy.mil/bupers-npc/reference/messages/Documents/NAVADMINS/NAV2019/NAV19216.txt">Apply for CSC/CMC lateral conversion</a>
+                    <a href="https://www.mynavyhr.navy.mil/Portals/55/Messages/NAVADMIN/NAV2019/NAV19216.txt">Apply for CSC/CMC lateral conversion</a>
                 </div>
 
                 <div class="box tile is-child">
                     <p class="heading">ALNAV 067/19</p>
-                    <a href="https://www.public.navy.mil/bupers-npc/reference/messages/Documents/ALNAVS/ALN2019/ALN19067.txt">Navy Lieutenant results are available</a>
+                    <a href="https://www.mynavyhr.navy.mil/Portals/55/Messages/ALNAV/ALN2019/ALN19067.txt">Navy Lieutenant results are available</a>
                 </div>
 
                 <div class="box tile is-child">


### PR DESCRIPTION
Updates the hyperlinks on the home page to point to the new MyNavy HR website instead of the old and unsupported NPC website. This change is essential because the redirect hyperlinks put in place for MyNavy HR only redirect to the new home page, they do not redirect to the specific NAVADMIN or ALNAV.

Fixes #6.